### PR TITLE
Improve "yarn install --frozen-lockfile"

### DIFF
--- a/common/test/utils.test.ts
+++ b/common/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { mocked } from 'ts-jest/utils'
-import { execSync, StdioOptions } from 'child_process'
+import { execSync } from 'child_process'
 import {
   readFileSync,
   writeFileSync,

--- a/common/test/utils.test.ts
+++ b/common/test/utils.test.ts
@@ -535,7 +535,7 @@ describe('parseBoolean', () => {
   })
 })
 
-describe('createExecutor', async () => {
+describe('createExecutor', () => {
   test('should return command executor and work correctly', () => {
     const cwd = 'source'
     const stdio = 'pipe'

--- a/deploy/src/main.ts
+++ b/deploy/src/main.ts
@@ -88,10 +88,21 @@ export const main = async (): Promise<void> => {
 
   core.info(`installing application dependencies`)
 
-  execSync(`yarn install --frozen-lockfile`, {
-    cwd: appDir,
-    stdio: 'inherit',
-  })
+  for (let retryIndex = 0; retryIndex < 10; retryIndex++) {
+    try {
+      execSync(`yarn install --frozen-lockfile`, {
+        cwd: appDir,
+        stdio: 'inherit',
+      })
+      break
+    } catch (error) {
+      if (/Couldn't find any versions for "@resolve-js/.test(`${error}`)) {
+        core.debug(`Retry ${retryIndex + 1}/10: yarn install --frozen-lockfile`)
+      } else {
+        throw error
+      }
+    }
+  }
 
   const randomizer = parseBoolean(core.getInput('randomize_name'))
     ? randomize

--- a/deploy/test/main.test.ts
+++ b/deploy/test/main.test.ts
@@ -274,6 +274,26 @@ test('app dependencies installation', async () => {
   })
 })
 
+test('tolerate to script "yarn install" execution errors', async () => {
+  let retryIndex = 0
+  mExec.mockImplementation((command: string) => {
+    if (retryIndex < 3 && command.includes('yarn install --frozen-lockfile')) {
+      retryIndex++
+      throw new Error(
+        `Couldn't find any versions for "@resolve-js/some-package-name" that matches "x.y.z"`
+      )
+    }
+    return Buffer.from('')
+  })
+
+  await main()
+
+  expect(mExec).toHaveBeenCalledWith('yarn install --frozen-lockfile', {
+    cwd: '/source/dir',
+    stdio: 'inherit',
+  })
+})
+
 test('cloud CLI requested', async () => {
   await main()
 

--- a/install-cloud/test/main.test.ts
+++ b/install-cloud/test/main.test.ts
@@ -56,7 +56,10 @@ beforeEach(() => {
     }
     return Buffer.from(result)
   })
-  mCreateExecutor.mockImplementation((command) => execSync)
+  mCreateExecutor.mockImplementation((command: string) => {
+    void command
+    return execSync
+  })
   mReadFile.mockReturnValue(
     Buffer.from(
       JSON.stringify({

--- a/publish/test/unpublish.test.ts
+++ b/publish/test/unpublish.test.ts
@@ -5,8 +5,6 @@ import { execSync } from 'child_process'
 import { mocked } from 'ts-jest/utils'
 import { unpublish } from '../src/unpublish'
 
-type Octokit = ReturnType<typeof github.getOctokit>
-
 jest.mock('@actions/core')
 jest.mock('@actions/github')
 jest.mock('fs')


### PR DESCRIPTION
Fix heisenbug
```
Error: Couldn't find any versions for "@resolve-js/eventstore-base" that matches "0.28.2" 
158 at MessageError.ExtendableBuiltin (/usr/share/yarn/lib/cli.js:721:66) 
159 at new MessageError (/usr/share/yarn/lib/cli.js:750:123) 
160 at Function.<anonymous> (/usr/share/yarn/lib/cli.js:50546:13) 
161 at Generator.next (<anonymous>) 
162 at step (/usr/share/yarn/lib/cli.js:310:30) 
163 at /usr/share/yarn/lib/cli.js:321:13 
164 at runMicrotasks (<anonymous>) 
165 at processTicksAndRejections (internal/process/task_queues.js:97:5) 
166Error: Error: Command failed: yarn install --frozen-lockfile
```